### PR TITLE
DL-19992: Decommission NCTS P5

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -25,8 +25,6 @@ class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig:
 
   val appName: String = configuration.get[String]("appName")
 
-  val phase6Enabled: Boolean = configuration.get[Boolean]("feature-flags.phase-6-enabled")
-
   val enrolmentProxyUrl: String      = servicesConfig.fullServiceUrl("enrolment-store-proxy")
   val eccEnrolmentSplashPage: String = configuration.get[String]("urls.eccEnrolmentSplashPage")
   val enrolmentKey: String           = configuration.get[String]("enrolment.key")

--- a/app/connectors/ReferenceDataConnector.scala
+++ b/app/connectors/ReferenceDataConnector.scala
@@ -38,10 +38,7 @@ class ReferenceDataConnector @Inject() (config: FrontendAppConfig, http: HttpCli
   private def get[T](url: URL)(implicit ec: ExecutionContext, hc: HeaderCarrier, reads: HttpReads[Responses[T]]): Future[Responses[T]] =
     http
       .get(url)
-      .setHeader(HeaderNames.Accept -> {
-        val version = if (config.phase6Enabled) "2.0" else "1.0"
-        s"application/vnd.hmrc.$version+json"
-      })
+      .setHeader(HeaderNames.Accept -> s"application/vnd.hmrc.2.0+json")
       .execute[Responses[T]]
 
   def getPreviousDocuments()(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Responses[Document]] = {
@@ -66,7 +63,7 @@ class ReferenceDataConnector @Inject() (config: FrontendAppConfig, http: HttpCli
     (_: String, url: String, response: HttpResponse) =>
       response.status match {
         case OK =>
-          val json = if (config.phase6Enabled) response.json else response.json \ "data"
+          val json = response.json
           json.validate[List[A]] match {
             case JsSuccess(Nil, _) =>
               Left(NoReferenceDataFoundException(url))

--- a/app/connectors/ReferenceDataConnector.scala
+++ b/app/connectors/ReferenceDataConnector.scala
@@ -43,19 +43,19 @@ class ReferenceDataConnector @Inject() (config: FrontendAppConfig, http: HttpCli
 
   def getPreviousDocuments()(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Responses[Document]] = {
     val url                             = url"${config.referenceDataUrl}/lists/PreviousDocumentType"
-    implicit val reads: Reads[Document] = Document.reads(Previous, config)
+    implicit val reads: Reads[Document] = Document.reads(Previous)
     get[Document](url)
   }
 
   def getSupportingDocuments()(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Responses[Document]] = {
     val url                             = url"${config.referenceDataUrl}/lists/SupportingDocumentType"
-    implicit val reads: Reads[Document] = Document.reads(Support, config)
+    implicit val reads: Reads[Document] = Document.reads(Support)
     get[Document](url)
   }
 
   def getTransportDocuments()(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Responses[Document]] = {
     val url                             = url"${config.referenceDataUrl}/lists/TransportDocumentType"
-    implicit val reads: Reads[Document] = Document.reads(Transport, config)
+    implicit val reads: Reads[Document] = Document.reads(Transport)
     get[Document](url)
   }
 

--- a/app/models/reference/Document.scala
+++ b/app/models/reference/Document.scala
@@ -31,7 +31,7 @@ case class Document(`type`: DocumentType, code: String, description: String) ext
 
 object Document {
 
-  def reads(`type`: DocumentType, config: FrontendAppConfig): Reads[Document] =
+  def reads(`type`: DocumentType): Reads[Document] =
     val (codeField, descriptionField) = ("key", "value")
     (
       (__ \ codeField).read[String] and

--- a/app/models/reference/Document.scala
+++ b/app/models/reference/Document.scala
@@ -32,7 +32,7 @@ case class Document(`type`: DocumentType, code: String, description: String) ext
 object Document {
 
   def reads(`type`: DocumentType, config: FrontendAppConfig): Reads[Document] =
-    val (codeField, descriptionField) = if (config.phase6Enabled) ("key", "value") else ("code", "description")
+    val (codeField, descriptionField) = ("key", "value")
     (
       (__ \ codeField).read[String] and
         (__ \ descriptionField).read[String]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -66,10 +66,6 @@ microservice {
   }
 }
 
-feature-flags {
-  phase-6-enabled: false
-}
-
 play.i18n.langCookieHttpOnly: "true"
 
 # Change this value to true to enable Welsh translations to be loaded from messages.cy, and to display the language toggle

--- a/it/test/connectors/ReferenceDataConnectorSpec.scala
+++ b/it/test/connectors/ReferenceDataConnectorSpec.scala
@@ -38,8 +38,6 @@ class ReferenceDataConnectorSpec extends ItSpecBase with WireMockServerHandler w
 
   private val baseUrl = "customs-reference-data/test-only"
 
-  private lazy val phase6App: GuiceApplicationBuilder => GuiceApplicationBuilder = _ => guiceApplicationBuilder()
-
   override def guiceApplicationBuilder(): GuiceApplicationBuilder = super
     .guiceApplicationBuilder()
     .configure(
@@ -48,153 +46,132 @@ class ReferenceDataConnectorSpec extends ItSpecBase with WireMockServerHandler w
 
   "getPreviousDocuments" - {
     val url = s"/$baseUrl/lists/PreviousDocumentType"
-    "when phase-6 " - {
 
-      val previousDocumentResponseJson: String =
-        s"""
-           |[
-           |  {
-           |    "key": "1",
-           |     "value": "Certificate of quality"
-           |    },
-           |  {
-           |      "key": "4",
-           |      "value": "Blah"
-           |    }
-           |]
-           |""".stripMargin
+    val previousDocumentResponseJson: String =
+      s"""
+          |[
+          |  {
+          |    "key": "1",
+          |     "value": "Certificate of quality"
+          |    },
+          |  {
+          |      "key": "4",
+          |      "value": "Blah"
+          |    }
+          |]
+          |""".stripMargin
 
-      "must return list of previous documents when successful" in {
-        running(phase6App) {
-          app =>
-            val connector = app.injector.instanceOf[ReferenceDataConnector]
-            server.stubFor(
-              get(urlEqualTo(url))
-                .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
-                .willReturn(okJson(previousDocumentResponseJson))
-            )
-            val expectResult = NonEmptySet.of(Document(Previous, "1", "Certificate of quality"), Document(Previous, "4", "Blah"))
+    "must return list of previous documents when successful" in {
+      server.stubFor(
+        get(urlEqualTo(url))
+          .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
+          .willReturn(okJson(previousDocumentResponseJson))
+      )
+      val expectResult = NonEmptySet.of(Document(Previous, "1", "Certificate of quality"), Document(Previous, "4", "Blah"))
 
-            connector.getPreviousDocuments().futureValue.value mustEqual expectResult
+      connector.getPreviousDocuments().futureValue.value mustEqual expectResult
+    }
+    "must throw a NoReferenceDataFoundException for an empty response" in {
+      checkNoReferenceDataFoundResponse(url, connector.getPreviousDocuments())
+    }
 
-        }
-      }
-      "must throw a NoReferenceDataFoundException for an empty response" in {
-        checkNoReferenceDataFoundResponse(url, connector.getPreviousDocuments())
-      }
+    "must return an exception when an error response is returned" in {
+      checkErrorResponse(url, connector.getPreviousDocuments())
+    }
 
-      "must return an exception when an error response is returned" in {
-        checkErrorResponse(url, connector.getPreviousDocuments())
-      }
-
-      "must return an exception when invalid JSON is returned" in {
-        checkJsErrorResponse(url, connector.getPreviousDocuments())
-      }
-
+    "must return an exception when invalid JSON is returned" in {
+      checkJsErrorResponse(url, connector.getPreviousDocuments())
     }
 
   }
 
   "getTransportDocuments" - {
     val url = s"/$baseUrl/lists/TransportDocumentType"
-    "when phase-6 " - {
-      val transportDocumentResponseJson: String =
-        s"""
-           |[
-           |  {
-           |    "key": "1",
-           |     "value": "Certificate of quality"
-           |    },
-           |  {
-           |      "key": "4",
-           |      "value": "Blah"
-           |    }
-           |]
-           |""".stripMargin
 
-      "must return list of documents when successful" in {
-        running(phase6App) {
-          app =>
-            val connector = app.injector.instanceOf[ReferenceDataConnector]
-            server.stubFor(
-              get(urlEqualTo(url))
-                .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
-                .willReturn(okJson(transportDocumentResponseJson))
-            )
+    val transportDocumentResponseJson: String =
+      s"""
+          |[
+          |  {
+          |    "key": "1",
+          |     "value": "Certificate of quality"
+          |    },
+          |  {
+          |      "key": "4",
+          |      "value": "Blah"
+          |    }
+          |]
+          |""".stripMargin
 
-            val expectResult = NonEmptySet.of(
-              Document(Transport, "1", "Certificate of quality"),
-              Document(Transport, "4", "Blah")
-            )
+    "must return list of documents when successful" in {
+      server.stubFor(
+        get(urlEqualTo(url))
+          .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
+          .willReturn(okJson(transportDocumentResponseJson))
+      )
 
-            connector.getTransportDocuments().futureValue.value mustEqual expectResult
-        }
+      val expectResult = NonEmptySet.of(
+        Document(Transport, "1", "Certificate of quality"),
+        Document(Transport, "4", "Blah")
+      )
 
-      }
-      "must throw a NoReferenceDataFoundException for an empty response" in {
-        checkNoReferenceDataFoundResponse(url, connector.getTransportDocuments())
-      }
+      connector.getTransportDocuments().futureValue.value mustEqual expectResult
+    }
+    "must throw a NoReferenceDataFoundException for an empty response" in {
+      checkNoReferenceDataFoundResponse(url, connector.getTransportDocuments())
+    }
 
-      "must return an exception when an error response is returned" in {
-        checkErrorResponse(url, connector.getTransportDocuments())
-      }
+    "must return an exception when an error response is returned" in {
+      checkErrorResponse(url, connector.getTransportDocuments())
+    }
 
-      "must return an exception when invalid JSON is returned" in {
-        checkJsErrorResponse(url, connector.getTransportDocuments())
-      }
+    "must return an exception when invalid JSON is returned" in {
+      checkJsErrorResponse(url, connector.getTransportDocuments())
     }
 
   }
 
   "getSupportingDocuments" - {
     val url = s"/$baseUrl/lists/SupportingDocumentType"
-    "when phase-6" - {
-      val supportingDocumentResponseJson: String =
-        s"""
-           |[
-           |  {
-           |    "key": "1",
-           |     "value": "Certificate of quality"
-           |    },
-           |  {
-           |      "key": "4",
-           |      "value": "Blah"
-           |    }
-           |]
-           |""".stripMargin
-      "must return list of documents when successful" in {
-        running(phase6App) {
-          app =>
-            val connector = app.injector.instanceOf[ReferenceDataConnector]
-            server.stubFor(
-              get(urlEqualTo(url))
-                .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
-                .willReturn(okJson(supportingDocumentResponseJson))
-            )
+    
+    val supportingDocumentResponseJson: String =
+      s"""
+          |[
+          |  {
+          |    "key": "1",
+          |     "value": "Certificate of quality"
+          |    },
+          |  {
+          |      "key": "4",
+          |      "value": "Blah"
+          |    }
+          |]
+          |""".stripMargin
+    "must return list of documents when successful" in {
+      server.stubFor(
+        get(urlEqualTo(url))
+          .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
+          .willReturn(okJson(supportingDocumentResponseJson))
+      )
 
-            val expectResult = NonEmptySet.of(
-              Document(Support, "1", "Certificate of quality"),
-              Document(Support, "4", "Blah")
-            )
+      val expectResult = NonEmptySet.of(
+        Document(Support, "1", "Certificate of quality"),
+        Document(Support, "4", "Blah")
+      )
 
-            connector.getSupportingDocuments().futureValue.value mustEqual expectResult
-        }
-
-      }
-
-      "must throw a NoReferenceDataFoundException for an empty response" in {
-        checkNoReferenceDataFoundResponse(url, connector.getSupportingDocuments())
-      }
-
-      "must return an exception when an error response is returned" in {
-        checkErrorResponse(url, connector.getSupportingDocuments())
-      }
-
-      "must return an exception when invalid JSON is returned" in {
-        checkJsErrorResponse(url, connector.getSupportingDocuments())
-      }
+      connector.getSupportingDocuments().futureValue.value mustEqual expectResult
     }
 
+    "must throw a NoReferenceDataFoundException for an empty response" in {
+      checkNoReferenceDataFoundResponse(url, connector.getSupportingDocuments())
+    }
+
+    "must return an exception when an error response is returned" in {
+      checkErrorResponse(url, connector.getSupportingDocuments())
+    }
+
+    "must return an exception when invalid JSON is returned" in {
+      checkJsErrorResponse(url, connector.getSupportingDocuments())
+    }
   }
 
   private def checkNoReferenceDataFoundResponse(url: String, result: => Future[Either[Exception, ?]]): Assertion = {
@@ -208,8 +185,6 @@ class ReferenceDataConnectorSpec extends ItSpecBase with WireMockServerHandler w
         .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
         .willReturn(okJson(json))
     )
-
-    println(result.futureValue)
 
     result.futureValue.left.value mustBe an[NoReferenceDataFoundException]
   }

--- a/it/test/connectors/ReferenceDataConnectorSpec.scala
+++ b/it/test/connectors/ReferenceDataConnectorSpec.scala
@@ -38,11 +38,7 @@ class ReferenceDataConnectorSpec extends ItSpecBase with WireMockServerHandler w
 
   private val baseUrl = "customs-reference-data/test-only"
 
-  private lazy val phase5App: GuiceApplicationBuilder => GuiceApplicationBuilder = _ =>
-    guiceApplicationBuilder().configure("feature-flags.phase-6-enabled" -> false)
-
-  private lazy val phase6App: GuiceApplicationBuilder => GuiceApplicationBuilder = _ =>
-    guiceApplicationBuilder().configure("feature-flags.phase-6-enabled" -> true)
+  private lazy val phase6App: GuiceApplicationBuilder => GuiceApplicationBuilder = _ => guiceApplicationBuilder()
 
   override def guiceApplicationBuilder(): GuiceApplicationBuilder = super
     .guiceApplicationBuilder()
@@ -96,63 +92,6 @@ class ReferenceDataConnectorSpec extends ItSpecBase with WireMockServerHandler w
       }
 
     }
-    "when phase-5 " - {
-      def documentsJson(docType: String): String =
-        s"""
-           |{
-           |"_links": {
-           |    "self": {
-           |      "href": "/customs-reference-data/lists/$docType"
-           |    }
-           |  },
-           |  "meta": {
-           |    "version": "410157ad-bc37-4e71-af2a-404d1ddad94c",
-           |    "snapshotDate": "2023-01-01"
-           |  },
-           |  "id": "$docType",
-           |  "data": [
-           |    {
-           |      "activeFrom": "2023-01-23",
-           |      "state": "valid",
-           |      "code": "1",
-           |      "description": "Certificate of quality"
-           |    },
-           |    {
-           |      "code": "4",
-           |      "description": "Blah"
-           |    }
-           |  ]
-           |}
-           |""".stripMargin
-
-      "must return list of previous documents when successful" in {
-        running(phase5App) {
-          app =>
-            val connector = app.injector.instanceOf[ReferenceDataConnector]
-            server.stubFor(
-              get(urlEqualTo(url))
-                .withHeader("Accept", equalTo("application/vnd.hmrc.1.0+json"))
-                .willReturn(okJson(documentsJson("Previous")))
-            )
-            val expectResult = NonEmptySet.of(Document(Previous, "1", "Certificate of quality"), Document(Previous, "4", "Blah"))
-
-            connector.getPreviousDocuments().futureValue.value mustEqual expectResult
-
-        }
-      }
-      "must throw a NoReferenceDataFoundException for an empty response" in {
-        checkNoReferenceDataFoundResponse(url, connector.getPreviousDocuments())
-      }
-
-      "must return an exception when an error response is returned" in {
-        checkErrorResponse(url, connector.getPreviousDocuments())
-      }
-
-      "must return an exception when invalid JSON is returned" in {
-        checkJsErrorResponse(url, connector.getPreviousDocuments())
-      }
-
-    }
 
   }
 
@@ -181,66 +120,6 @@ class ReferenceDataConnectorSpec extends ItSpecBase with WireMockServerHandler w
               get(urlEqualTo(url))
                 .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
                 .willReturn(okJson(transportDocumentResponseJson))
-            )
-
-            val expectResult = NonEmptySet.of(
-              Document(Transport, "1", "Certificate of quality"),
-              Document(Transport, "4", "Blah")
-            )
-
-            connector.getTransportDocuments().futureValue.value mustEqual expectResult
-        }
-
-      }
-      "must throw a NoReferenceDataFoundException for an empty response" in {
-        checkNoReferenceDataFoundResponse(url, connector.getTransportDocuments())
-      }
-
-      "must return an exception when an error response is returned" in {
-        checkErrorResponse(url, connector.getTransportDocuments())
-      }
-
-      "must return an exception when invalid JSON is returned" in {
-        checkJsErrorResponse(url, connector.getTransportDocuments())
-      }
-    }
-    "when phase-5 " - {
-      def documentsJson(docType: String): String =
-        s"""
-           |{
-           |"_links": {
-           |    "self": {
-           |      "href": "/customs-reference-data/lists/$docType"
-           |    }
-           |  },
-           |  "meta": {
-           |    "version": "410157ad-bc37-4e71-af2a-404d1ddad94c",
-           |    "snapshotDate": "2023-01-01"
-           |  },
-           |  "id": "$docType",
-           |  "data": [
-           |    {
-           |      "activeFrom": "2023-01-23",
-           |      "state": "valid",
-           |      "code": "1",
-           |      "description": "Certificate of quality"
-           |    },
-           |    {
-           |      "code": "4",
-           |      "description": "Blah"
-           |    }
-           |  ]
-           |}
-           |""".stripMargin
-
-      "must return list of documents when successful" in {
-        running(phase5App) {
-          app =>
-            val connector = app.injector.instanceOf[ReferenceDataConnector]
-            server.stubFor(
-              get(urlEqualTo(url))
-                .withHeader("Accept", equalTo("application/vnd.hmrc.1.0+json"))
-                .willReturn(okJson(documentsJson("Transport")))
             )
 
             val expectResult = NonEmptySet.of(
@@ -315,82 +194,22 @@ class ReferenceDataConnectorSpec extends ItSpecBase with WireMockServerHandler w
         checkJsErrorResponse(url, connector.getSupportingDocuments())
       }
     }
-    "when phase-5" - {
-      def documentsJson(docType: String): String =
-        s"""
-           |{
-           |"_links": {
-           |    "self": {
-           |      "href": "/customs-reference-data/lists/$docType"
-           |    }
-           |  },
-           |  "meta": {
-           |    "version": "410157ad-bc37-4e71-af2a-404d1ddad94c",
-           |    "snapshotDate": "2023-01-01"
-           |  },
-           |  "id": "$docType",
-           |  "data": [
-           |    {
-           |      "activeFrom": "2023-01-23",
-           |      "state": "valid",
-           |      "code": "1",
-           |      "description": "Certificate of quality"
-           |    },
-           |    {
-           |      "code": "4",
-           |      "description": "Blah"
-           |    }
-           |  ]
-           |}
-           |""".stripMargin
-      "must return list of documents when successful" in {
-        running(phase5App) {
-          app =>
-            val connector = app.injector.instanceOf[ReferenceDataConnector]
-            server.stubFor(
-              get(urlEqualTo(url))
-                .withHeader("Accept", equalTo("application/vnd.hmrc.1.0+json"))
-                .willReturn(okJson(documentsJson("Supporting")))
-            )
-
-            val expectResult = NonEmptySet.of(
-              Document(Support, "1", "Certificate of quality"),
-              Document(Support, "4", "Blah")
-            )
-
-            connector.getSupportingDocuments().futureValue.value mustEqual expectResult
-        }
-
-      }
-
-      "must throw a NoReferenceDataFoundException for an empty response" in {
-        checkNoReferenceDataFoundResponse(url, connector.getSupportingDocuments())
-      }
-
-      "must return an exception when an error response is returned" in {
-        checkErrorResponse(url, connector.getSupportingDocuments())
-      }
-
-      "must return an exception when invalid JSON is returned" in {
-        checkJsErrorResponse(url, connector.getSupportingDocuments())
-      }
-    }
 
   }
 
   private def checkNoReferenceDataFoundResponse(url: String, result: => Future[Either[Exception, ?]]): Assertion = {
     val json: String =
       """
-        |{
-        |  "data": []
-        |}
+        |[]
         |""".stripMargin
 
     server.stubFor(
       get(urlEqualTo(url))
-        .withHeader("Accept", equalTo("application/vnd.hmrc.1.0+json"))
+        .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
         .willReturn(okJson(json))
     )
+
+    println(result.futureValue)
 
     result.futureValue.left.value mustBe an[NoReferenceDataFoundException]
   }
@@ -402,7 +221,7 @@ class ReferenceDataConnectorSpec extends ItSpecBase with WireMockServerHandler w
       errorResponse =>
         server.stubFor(
           get(urlEqualTo(url))
-            .withHeader("Accept", equalTo("application/vnd.hmrc.1.0+json"))
+            .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
             .willReturn(
               aResponse()
                 .withStatus(errorResponse)
@@ -423,7 +242,7 @@ class ReferenceDataConnectorSpec extends ItSpecBase with WireMockServerHandler w
 
     server.stubFor(
       get(urlEqualTo(url))
-        .withHeader("Accept", equalTo("application/vnd.hmrc.1.0+json"))
+        .withHeader("Accept", equalTo("application/vnd.hmrc.2.0+json"))
         .willReturn(okJson(json))
     )
 

--- a/test/models/reference/DocumentSpec.scala
+++ b/test/models/reference/DocumentSpec.scala
@@ -34,47 +34,8 @@ class DocumentSpec extends SpecBase with ScalaCheckPropertyChecks with Generator
 
   "referenceDataReads" - {
     "must deserialise json from reference data service" - {
-      "when phase-5 " - {
-        "when transport" in {
-          when(mockFrontendAppConfig.phase6Enabled).thenReturn(false)
-          val json = Json.parse("""
-              |{
-              |  "code" : "code",
-              |  "description" : "description"
-              |}
-              |""".stripMargin)
-
-          json.as[Document](Document.reads(Transport, mockFrontendAppConfig)) mustEqual Document(Transport, "code", "description")
-        }
-
-        "when support" in {
-          when(mockFrontendAppConfig.phase6Enabled).thenReturn(false)
-          val json = Json.parse("""
-              |{
-              |  "code" : "code",
-              |  "description" : "description"
-              |}
-              |""".stripMargin)
-
-          json.as[Document](Document.reads(Support, mockFrontendAppConfig)) mustEqual Document(Support, "code", "description")
-        }
-
-        "when previous" in {
-          when(mockFrontendAppConfig.phase6Enabled).thenReturn(false)
-          val json = Json.parse("""
-              |{
-              |  "code" : "code",
-              |  "description" : "description"
-              |}
-              |""".stripMargin)
-
-          json.as[Document](Document.reads(Previous, mockFrontendAppConfig)) mustEqual Document(Previous, "code", "description")
-
-        }
-      }
       "when phase-6 " - {
         "when transport" in {
-          when(mockFrontendAppConfig.phase6Enabled).thenReturn(true)
           val json = Json.parse("""
               | {
               |  "key" : "code",
@@ -86,7 +47,6 @@ class DocumentSpec extends SpecBase with ScalaCheckPropertyChecks with Generator
         }
 
         "when support" in {
-          when(mockFrontendAppConfig.phase6Enabled).thenReturn(true)
           val json = Json.parse("""
               | {
               |  "key" : "code",
@@ -98,7 +58,6 @@ class DocumentSpec extends SpecBase with ScalaCheckPropertyChecks with Generator
         }
 
         "when previous" in {
-          when(mockFrontendAppConfig.phase6Enabled).thenReturn(true)
           val json = Json.parse("""
               | {
               |  "key" : "code",

--- a/test/models/reference/DocumentSpec.scala
+++ b/test/models/reference/DocumentSpec.scala
@@ -34,84 +34,82 @@ class DocumentSpec extends SpecBase with ScalaCheckPropertyChecks with Generator
 
   "referenceDataReads" - {
     "must deserialise json from reference data service" - {
-      "when phase-6 " - {
-        "when transport" in {
-          val json = Json.parse("""
-              | {
-              |  "key" : "code",
-              |  "value" : "description"
-              | }
-              |""".stripMargin)
+      "when transport" in {
+        val json = Json.parse("""
+            | {
+            |  "key" : "code",
+            |  "value" : "description"
+            | }
+            |""".stripMargin)
 
-          json.as[Document](Document.reads(Transport, mockFrontendAppConfig)) mustEqual Document(Transport, "code", "description")
-        }
-
-        "when support" in {
-          val json = Json.parse("""
-              | {
-              |  "key" : "code",
-              |  "value" : "description"
-              | }
-              |""".stripMargin)
-
-          json.as[Document](Document.reads(Support, mockFrontendAppConfig)) mustEqual Document(Support, "code", "description")
-        }
-
-        "when previous" in {
-          val json = Json.parse("""
-              | {
-              |  "key" : "code",
-              |  "value" : "description"
-              | }
-              |""".stripMargin)
-
-          json.as[Document](Document.reads(Previous, mockFrontendAppConfig)) mustEqual Document(Previous, "code", "description")
-        }
+        json.as[Document](Document.reads(Transport, mockFrontendAppConfig)) mustEqual Document(Transport, "code", "description")
       }
-      "when reading PreviousDocument from mongo" in {
-        forAll(Gen.alphaNumStr, Gen.alphaNumStr) {
-          (code, description) =>
-            val previousDocument = Document(Previous, code, description)
-            Json
-              .parse(s"""
-                   |{
-                   |"type": "Previous",
-                   |"code" : "$code",
-                   |"description": "$description"
-                   |}
-                   |""".stripMargin)
-              .as[Document] mustEqual previousDocument
-        }
+
+      "when support" in {
+        val json = Json.parse("""
+            | {
+            |  "key" : "code",
+            |  "value" : "description"
+            | }
+            |""".stripMargin)
+
+        json.as[Document](Document.reads(Support, mockFrontendAppConfig)) mustEqual Document(Support, "code", "description")
       }
-      "when reading SupportDocument from mongo" in {
-        forAll(Gen.alphaNumStr, Gen.alphaNumStr) {
-          (code, description) =>
-            val previousDocument = Document(Support, code, description)
-            Json
-              .parse(s"""
-                   |{
-                   |"type": "Support",
-                   |"code": "$code",
-                   |"description": "$description"
-                   |}
-                   |""".stripMargin)
-              .as[Document] mustEqual previousDocument
-        }
+
+      "when previous" in {
+        val json = Json.parse("""
+            | {
+            |  "key" : "code",
+            |  "value" : "description"
+            | }
+            |""".stripMargin)
+
+        json.as[Document](Document.reads(Previous, mockFrontendAppConfig)) mustEqual Document(Previous, "code", "description")
       }
-      "when reading TransportDocument from mongo" in {
-        forAll(Gen.alphaNumStr, Gen.alphaNumStr) {
-          (code, description) =>
-            val previousDocument = Document(Transport, code, description)
-            Json
-              .parse(s"""
-                   |{
-                   |"type": "Transport",
-                   |"code" : "$code",
-                   |"description": "$description"
-                   |}
-                   |""".stripMargin)
-              .as[Document] mustEqual previousDocument
-        }
+    }
+    "when reading PreviousDocument from mongo" in {
+      forAll(Gen.alphaNumStr, Gen.alphaNumStr) {
+        (code, description) =>
+          val previousDocument = Document(Previous, code, description)
+          Json
+            .parse(s"""
+                  |{
+                  |"type": "Previous",
+                  |"code" : "$code",
+                  |"description": "$description"
+                  |}
+                  |""".stripMargin)
+            .as[Document] mustEqual previousDocument
+      }
+    }
+    "when reading SupportDocument from mongo" in {
+      forAll(Gen.alphaNumStr, Gen.alphaNumStr) {
+        (code, description) =>
+          val previousDocument = Document(Support, code, description)
+          Json
+            .parse(s"""
+                  |{
+                  |"type": "Support",
+                  |"code": "$code",
+                  |"description": "$description"
+                  |}
+                  |""".stripMargin)
+            .as[Document] mustEqual previousDocument
+      }
+    }
+    "when reading TransportDocument from mongo" in {
+      forAll(Gen.alphaNumStr, Gen.alphaNumStr) {
+        (code, description) =>
+          val previousDocument = Document(Transport, code, description)
+          Json
+            .parse(s"""
+                  |{
+                  |"type": "Transport",
+                  |"code" : "$code",
+                  |"description": "$description"
+                  |}
+                  |""".stripMargin)
+            .as[Document] mustEqual previousDocument
       }
     }
   }

--- a/test/models/reference/DocumentSpec.scala
+++ b/test/models/reference/DocumentSpec.scala
@@ -30,8 +30,6 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.select.SelectItem
 
 class DocumentSpec extends SpecBase with ScalaCheckPropertyChecks with Generators {
 
-  private val mockFrontendAppConfig: FrontendAppConfig = mock[FrontendAppConfig]
-
   "referenceDataReads" - {
     "must deserialise json from reference data service" - {
       "when transport" in {
@@ -42,7 +40,7 @@ class DocumentSpec extends SpecBase with ScalaCheckPropertyChecks with Generator
             | }
             |""".stripMargin)
 
-        json.as[Document](Document.reads(Transport, mockFrontendAppConfig)) mustEqual Document(Transport, "code", "description")
+        json.as[Document](Document.reads(Transport)) mustEqual Document(Transport, "code", "description")
       }
 
       "when support" in {
@@ -53,7 +51,7 @@ class DocumentSpec extends SpecBase with ScalaCheckPropertyChecks with Generator
             | }
             |""".stripMargin)
 
-        json.as[Document](Document.reads(Support, mockFrontendAppConfig)) mustEqual Document(Support, "code", "description")
+        json.as[Document](Document.reads(Support)) mustEqual Document(Support, "code", "description")
       }
 
       "when previous" in {
@@ -64,7 +62,7 @@ class DocumentSpec extends SpecBase with ScalaCheckPropertyChecks with Generator
             | }
             |""".stripMargin)
 
-        json.as[Document](Document.reads(Previous, mockFrontendAppConfig)) mustEqual Document(Previous, "code", "description")
+        json.as[Document](Document.reads(Previous)) mustEqual Document(Previous, "code", "description")
       }
     }
     "when reading PreviousDocument from mongo" in {


### PR DESCRIPTION
[[DL-19992]](https://jira.tools.tax.service.gov.uk/browse/DL-19992)

Remove the Phase 6 feature flag and Phase 5 variants of code as P5 is now obsolete.

manage-transit-movements-ui-journey-tests- DepatureFes.DocumentsSpec:
<img width="553" height="101" alt="image" src="https://github.com/user-attachments/assets/b5be3cc5-2dc5-457a-9c3c-f75ebd8c63af" />